### PR TITLE
replace @navigation with @layout except issue

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -3643,7 +3643,7 @@ laid out spatially relative to the current document.
 
 <p>Four new properties are allowed inside @layout: nav-up, nav-right, nav-bottom, nav-right. 
 
-<p class=note>The name of the properties inside @navigation are borrowed from <a href="http://www.w3.org/TR/2004/CR-css3-ui-20040511/#nav-dir">CSS3 Basic User Interface Module</a>.
+<p class=note>The name of the properties inside @layout are borrowed from <a href="http://www.w3.org/TR/2004/CR-css3-ui-20040511/#nav-dir">CSS3 Basic User Interface Module</a>.
 
 <p>The properties accept these values:
 
@@ -3676,7 +3676,7 @@ laid out spatially relative to the current document.
 
 <div class=example>
 <pre>
-@navigation {
+@layout {
   nav-left: back;
 }
 </pre>
@@ -3739,7 +3739,7 @@ relative to the document, not to the style sheet.
 <h3>Page shift effects</h3>
 
 <p>To describe page shift effects, four new properties inside
-@navigation are proposed: nav-up-shift, nav-right-shift,
+@layout are proposed: nav-up-shift, nav-right-shift,
 nav-down-shift, nav-left-shift. These properties take one of several
 keyword values:
 
@@ -3764,7 +3764,7 @@ there better ways to describe transitions?
 
 <div class=example>
 <pre>
-@navigation {
+@layout {
    nav-up-shift: pan;
    nav-down-shift: flip;
 }


### PR DESCRIPTION
Now spatial layout of page's @-rule is `@layout`, not `@navigation`.
http://books.spec.whatwg.org/#spatial-layout-of-pages;-@layout

> Issue: alternative name: @navigation, @neighborhood, @hood

http://books.spec.whatwg.org/#spatial-layout-of-pages;-@layout
